### PR TITLE
allow building a model without validating input

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ result = PersonFactory.batch(size=5)  # list[Person, Person, Person, Person, Per
 Any `kwargs` you pass to `.build`, `.batch` or any of the [persistence methods](#persistence), will take precedence over
 whatever defaults are defined on the factory class itself.
 
+By default, when building a pydantic class, kwargs are validated, to avoid input validation you can use the `factory_use_construct` param.
+```python
+result = PersonFactory.build(id=5)  # Raises a validation error
+
+result = PersonFactory.build(factory_use_construct=True, id=5)  # Build a Person with invalid id
+```
+
 ### Nested Models and Complex types
 
 The automatic generation of mock data works for all types supported by pydantic, as well as nested classes that derive

--- a/pydantic_factories/exceptions.py
+++ b/pydantic_factories/exceptions.py
@@ -12,3 +12,7 @@ class ParameterError(ModelFactoryError):
 
 class MissingBuildKwargError(ModelFactoryError):
     pass
+
+
+class NotSupportedWithDataClassesError(ModelFactoryError):
+    pass

--- a/pydantic_factories/factory.py
+++ b/pydantic_factories/factory.py
@@ -445,7 +445,7 @@ class ModelFactory(ABC, Generic[T]):
                     kwargs[field_name] = cls.get_field_value(model_field=model_field)
         if factory_use_construct:
             if is_pydantic_model(cls.__model__):
-                return cls.__model__.construct(**kwargs)  # type: ignore
+                return cast(BaseModel, cls.__model__).construct(**kwargs)
             raise NotSupportedWithDataClassesError("factory_use_construct is not allowed to be used with dataclasses")
         return cls.__model__(**kwargs)
 

--- a/pydantic_factories/factory.py
+++ b/pydantic_factories/factory.py
@@ -97,6 +97,7 @@ from pydantic_factories.constraints.strings import (
 from pydantic_factories.exceptions import (
     ConfigurationError,
     MissingBuildKwargError,
+    NotSupportedWithDataClassesError,
     ParameterError,
 )
 from pydantic_factories.fields import Ignore, Require
@@ -427,8 +428,13 @@ class ModelFactory(ABC, Generic[T]):
         return model.__fields__.items()  # type: ignore
 
     @classmethod
-    def build(cls, **kwargs) -> T:
-        """builds an instance of the factory's Meta.model"""
+    def build(cls, factory_use_construct: bool = False, **kwargs) -> T:
+        """
+        builds an instance of the factory's Meta.model
+
+        If factory_use_construct is True, then no validations will be made when instantiating the model,
+        see: https://pydantic-docs.helpmanual.io/usage/models/#creating-models-without-validation.
+        """
         for field_name, model_field in cls.get_model_fields(cls._get_model()):
             if model_field.alias:
                 field_name = model_field.alias
@@ -437,6 +443,10 @@ class ModelFactory(ABC, Generic[T]):
                     kwargs[field_name] = cls.handle_factory_field(field_name=field_name)
                 else:
                     kwargs[field_name] = cls.get_field_value(model_field=model_field)
+        if factory_use_construct:
+            if is_pydantic_model(cls.__model__):
+                return cls.__model__.construct(**kwargs)  # type: ignore
+            raise NotSupportedWithDataClassesError("factory_use_construct is not allowed to be used with dataclasses")
         return cls.__model__(**kwargs)
 
     @classmethod


### PR DESCRIPTION
Added a new param to build function to allow building a pydantic model without validating input using the construct method as discussed [here](https://github.com/Goldziher/pydantic-factories/issues/15) 