### PR TITLE
Use TypeVar's bound instead of constraint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     rev: "v2.12.2"
     hooks:
       - id: pylint
-        exclude: "test_*"
+        exclude: "/(test_|conftest.py)"
         args:
           [
             "--unsafe-load-any-extension=y"
@@ -64,7 +64,7 @@ repos:
     rev: "v0.930"
     hooks:
       - id: mypy
-        exclude: "test_*"
+        exclude: "/(test_|conftest.py)"
         additional_dependencies: [
           pydantic,
           faker

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,5 +18,5 @@ init_typed = True
 warn_required_dynamic_aliases = True
 warn_untyped_fields = True
 
-[mypy-pydantic_factories.strict_typing_check
+[mypy-tests.typing_test_strict]
 disallow_any_generics = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,6 @@ init_forbid_extra = True
 init_typed = True
 warn_required_dynamic_aliases = True
 warn_untyped_fields = True
+
+[mypy-pydantic_factories.strict_typing_check
+disallow_any_generics = True

--- a/pydantic_factories/factory.py
+++ b/pydantic_factories/factory.py
@@ -117,7 +117,7 @@ from pydantic_factories.value_generators.primitives import (
     create_random_bytes,
 )
 
-T = TypeVar("T", BaseModel, DataclassProtocol)
+T = TypeVar("T", bound=Union[BaseModel, DataclassProtocol])
 
 default_faker = Faker()
 
@@ -487,7 +487,7 @@ class ModelFactory(ABC, Generic[T]):
             if is_pydantic_model(cls.__model__):
                 return cls.__model__.construct(**kwargs)  # type: ignore
             raise ConfigurationError("factory_use_construct requires a pydantic model as the factory's __model__")
-        return cls.__model__(**kwargs)
+        return cast(T, cls.__model__(**kwargs))
 
     @classmethod
     def batch(cls, size: int, **kwargs: Any) -> List[T]:

--- a/pydantic_factories/protocols.py
+++ b/pydantic_factories/protocols.py
@@ -1,19 +1,19 @@
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Dict, List, TypeVar, Union
 
 from pydantic import BaseModel
 from typing_extensions import Protocol
 
 
+# According to https://github.com/python/cpython/blob/main/Lib/dataclasses.py#L1213
+# having __dataclass_fields__ is enough to identity a dataclass.
 class DataclassProtocol(Protocol):
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=super-init-not-called
         ...  # pragma: no cover
 
     __dataclass_fields__: Dict
-    __dataclass_params__: Dict
-    __post_init__: Optional[Callable]
 
 
-T = TypeVar("T", BaseModel, DataclassProtocol)
+T = TypeVar("T", bound=Union[BaseModel, DataclassProtocol])
 
 
 class SyncPersistenceProtocol(Protocol[T]):

--- a/pydantic_factories/strict_typing_check.py
+++ b/pydantic_factories/strict_typing_check.py
@@ -1,0 +1,32 @@
+import dataclasses
+
+import pydantic.dataclasses
+from pydantic import BaseModel
+
+from pydantic_factories import ModelFactory
+
+
+class PydanticClass(BaseModel):
+    field: str
+
+
+class PydanticClassFactory(ModelFactory[PydanticClass]):
+    __model__ = PydanticClass
+
+
+@pydantic.dataclasses.dataclass
+class PydanticDataClass:
+    field: str
+
+
+class PydanticDataClassFactory(ModelFactory[PydanticDataClass]):
+    __model__ = PydanticDataClass
+
+
+@dataclasses.dataclass()
+class PythonDataClass:
+    field: str
+
+
+class PythonDataClassFactory(ModelFactory[PythonDataClass]):
+    __model__ = PythonDataClass

--- a/tests/typing_test_strict.py
+++ b/tests/typing_test_strict.py
@@ -1,3 +1,7 @@
+"""Module exists only to test generic boundaries.
+
+Filename should not start with "test_".
+"""
 import dataclasses
 
 import pydantic.dataclasses


### PR DESCRIPTION
Using a factory in mypy strict requires a typed generic and providing
the model itself as the generic type did not work because contrained
TypeVar doesn't allow subclassing, as a bound TypeVar allows it.

A file with this typing with its own mypy config was added to test the
behaviour remains.   Adding this showed that the DataclassProtocol
was too narrow as a single field dataclass does not have
`__dataclass_params__` and `__post_init__` attributes and it seems
that marking them as Optional is not enough.

**EDIT** BONUS: fix exclusion regex in pre-commit

Fixes #21

# Notes
**EDIT** This is fixed, was an issue with the exclusion regex.
~I added a test for this...  I really tried hard to put the `pydantic_factories/strict_typing_check.py` file in the tests folder but i just couldn't figure out how to have it typed check in the `mypy.ini`.   Something like `[mypy-test.strict_typing_check]` didn't seem to check the file at all.~

~If you have any suggestion where to put it?  or how to make it work in the tests folder.   Could also not package it... ?~