### PR TITLE
Fix OrmarModelFactory creation for relational field

### DIFF
--- a/pydantic_factories/extensions/ormar_orm.py
+++ b/pydantic_factories/extensions/ormar_orm.py
@@ -22,6 +22,7 @@ class OrmarModelFactory(ModelFactory[Model]):  # pragma: no cover
         We need to handle here both choices and the fact that ormar sets values to be optional
         """
         model_field.required = True
-        if hasattr(model_field.field_info, "choices") and len(model_field.field_info.choices) > 0:  # type: ignore
+        choices = getattr(model_field.field_info, "choices", False)
+        if choices and len(model_field.field_info.choices) > 0:  # type: ignore
             return random.choice(list(model_field.field_info.choices))  # type: ignore
         return super().get_field_value(model_field=model_field)

--- a/tests/extensions/test_ormar_extension.py
+++ b/tests/extensions/test_ormar_extension.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from enum import Enum
+from typing import Dict, Optional, Union
 
+import ormar
 import sqlalchemy
 from databases import Database
 from ormar import DateTime, Integer, Model, String
@@ -33,8 +35,21 @@ class Person(Model):
         pass
 
 
+class Job(Model):
+    id: int = Integer(autoincrement=True, primary_key=True)
+    person: Optional[Union[Person, Dict]] = ormar.ForeignKey(Person)
+    name: str = String(max_length=20)
+
+    class Meta(BaseMeta):
+        pass
+
+
 class PersonFactory(OrmarModelFactory):
     __model__ = Person
+
+
+class JobFactory(OrmarModelFactory):
+    __model__ = Job
 
 
 def test_person_factory():
@@ -44,3 +59,12 @@ def test_person_factory():
     assert result.created_at
     assert result.updated_at
     assert result.mood
+
+
+def test_job_factory():
+    job_name: str = "Unemployed"
+    result = JobFactory.build(name=job_name)
+
+    assert result.id
+    assert result.name == job_name
+    assert result.person

--- a/tests/extensions/test_ormar_extension.py
+++ b/tests/extensions/test_ormar_extension.py
@@ -2,10 +2,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, Optional, Union
 
-import ormar
 import sqlalchemy
 from databases import Database
-from ormar import DateTime, Integer, Model, String
+from ormar import DateTime, ForeignKey, Integer, Model, String
 from sqlalchemy import func
 
 from pydantic_factories.extensions import OrmarModelFactory
@@ -37,7 +36,7 @@ class Person(Model):
 
 class Job(Model):
     id: int = Integer(autoincrement=True, primary_key=True)
-    person: Optional[Union[Person, Dict]] = ormar.ForeignKey(Person)
+    person: Optional[Union[Person, Dict]] = ForeignKey(Person)
     name: str = String(max_length=20)
 
     class Meta(BaseMeta):


### PR DESCRIPTION
This PR fixes #27, where `pydantic-factories` is unable to create an instance of `ormar.Model` model if it contains a `ormar.ForeignKey` field to another model.

As the issue describes, the previous `hasattr(model_field.field_info, "choices")` check was error prone, as for the `ForeignKey` field this attribute was set to `False`, which passed the check and resulted in an error when trying to check `len()` of a boolean.