### PR TITLE
Use default random instance

### DIFF
--- a/pydantic_factories/constraints/constrained_collection_handler.py
+++ b/pydantic_factories/constraints/constrained_collection_handler.py
@@ -1,3 +1,4 @@
+import random
 from typing import TYPE_CHECKING, Any, Union, cast
 
 from pydantic import ConstrainedList, ConstrainedSet
@@ -5,7 +6,6 @@ from pydantic.fields import ModelField
 from typing_extensions import Type
 
 from pydantic_factories.exceptions import ParameterError
-from pydantic_factories.utils import random
 from pydantic_factories.value_generators.complex_types import handle_complex_type
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/pydantic_factories/extensions/ormar_orm.py
+++ b/pydantic_factories/extensions/ormar_orm.py
@@ -1,10 +1,11 @@
+import random
 from typing import Any
 
 from pydantic import BaseModel
 from pydantic.fields import ModelField
 
 from pydantic_factories.factory import ModelFactory
-from pydantic_factories.utils import is_pydantic_model, is_union, random
+from pydantic_factories.utils import is_pydantic_model, is_union
 
 try:
     from ormar import Model

--- a/pydantic_factories/factory.py
+++ b/pydantic_factories/factory.py
@@ -1,4 +1,5 @@
 import os
+import random
 from abc import ABC
 from collections import Counter, deque
 from contextlib import suppress
@@ -110,7 +111,6 @@ from pydantic_factories.utils import (
     is_literal,
     is_optional,
     is_pydantic_model,
-    random,
 )
 from pydantic_factories.value_generators.complex_types import handle_complex_type
 from pydantic_factories.value_generators.primitives import (

--- a/pydantic_factories/utils.py
+++ b/pydantic_factories/utils.py
@@ -2,7 +2,6 @@ from dataclasses import Field as DataclassField
 from dataclasses import fields as get_dataclass_fields
 from decimal import Decimal
 from inspect import isclass
-from random import Random
 from typing import Any, Tuple, Type, TypeVar, cast
 
 from pydantic import BaseModel, create_model
@@ -12,7 +11,6 @@ from pydantic.utils import almost_equal_floats
 from pydantic_factories.protocols import DataclassProtocol
 
 T = TypeVar("T", int, float, Decimal)
-random = Random()
 
 
 def passes_pydantic_multiple_validator(value: T, multiple_of: T) -> bool:

--- a/pydantic_factories/value_generators/complex_types.py
+++ b/pydantic_factories/value_generators/complex_types.py
@@ -1,3 +1,4 @@
+import random
 from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any, Optional, Type, cast
 
@@ -16,7 +17,7 @@ from pydantic.fields import (
     ModelField,
 )
 
-from pydantic_factories.utils import is_any, is_union, random
+from pydantic_factories.utils import is_any, is_union
 from pydantic_factories.value_generators.primitives import create_random_string
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/pydantic_factories/value_generators/constrained_number.py
+++ b/pydantic_factories/value_generators/constrained_number.py
@@ -1,9 +1,10 @@
+import random
 from decimal import Decimal
 from typing import Callable, Optional, Tuple, TypeVar, cast
 
 from typing_extensions import Type
 
-from pydantic_factories.utils import passes_pydantic_multiple_validator, random
+from pydantic_factories.utils import passes_pydantic_multiple_validator
 
 T = TypeVar("T", Decimal, int, float)
 

--- a/pydantic_factories/value_generators/primitives.py
+++ b/pydantic_factories/value_generators/primitives.py
@@ -1,9 +1,7 @@
+import random
 from binascii import hexlify
 from decimal import Decimal
-from os import urandom
 from typing import Optional, Union
-
-from pydantic_factories.utils import random
 
 
 def create_random_float(
@@ -36,7 +34,7 @@ def create_random_bytes(
     if max_length is None:
         max_length = min_length + 1 * 2
     length = random.randint(min_length, max_length)
-    result = hexlify(urandom(length))
+    result = hexlify(random.randbytes(length))
     if lower_case:
         result = result.lower()
     if max_length and len(result) > max_length:

--- a/tests/test_random_seed.py
+++ b/tests/test_random_seed.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel, Field
+
+from pydantic_factories import ModelFactory
+
+
+def test_random_seed():
+    class MyModel(BaseModel):
+        id: int
+        special_id: str = Field(regex=r"ID-[1-9]{3}\.[1-9]{3}")
+
+    class MyModelFactory(ModelFactory):
+        __model__ = MyModel
+
+    ModelFactory.seed_random(1651)
+
+    ins = MyModelFactory.build()
+
+    assert ins.id == 4
+    assert ins.special_id == "ID-515.943"


### PR DESCRIPTION
This is a quick fix to be able to seed the `exrex` package
without having two different instances of the `Random` classes.