### PR TITLE
Recognize the allow_population_by_field_name flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ max-args = 10
 max-attributes = 10
 max-locals = 12
 max-returns = 10
+max-public-methods=21
 
 [tool.pylint.VARIABLES]
 ignored-argument-names = "args|kwargs|_|__"

--- a/tests/test_factory_build.py
+++ b/tests/test_factory_build.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass as vanilla_dataclass
 from uuid import uuid4
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from pydantic_factories import ModelFactory
 from pydantic_factories.exceptions import ConfigurationError
@@ -85,3 +85,31 @@ def test_factory_use_construct():
 
     with pytest.raises(ConfigurationError):
         MyFactory.build(factory_use_construct=True)
+
+
+def test_build_instance_by_field_alias_with_allow_population_by_field_name_flag():
+    class MyModel(BaseModel):
+        aliased_field: str = Field(..., alias="special_field")
+
+        class Config:
+            allow_population_by_field_name = True
+
+    class MyFactory(ModelFactory):
+        __model__ = MyModel
+
+    instance = MyFactory.build(aliased_field="some")
+    assert instance.aliased_field == "some"
+
+
+def test_build_instance_by_field_name_with_allow_population_by_field_name_flag():
+    class MyModel(BaseModel):
+        aliased_field: str = Field(..., alias="special_field")
+
+        class Config:
+            allow_population_by_field_name = True
+
+    class MyFactory(ModelFactory):
+        __model__ = MyModel
+
+    instance = MyFactory.build(special_field="some")
+    assert instance.aliased_field == "some"


### PR DESCRIPTION
Consider the allow_population_by_field_name flag when building an instance from pydantic model

The allow_population_by_field_name flag participates in making a decision about using an alias field name