### PR TITLE
Fix error when building Pydantic models with Mapping fields [Issue #61]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,3 +177,7 @@
 [1.5.3]
 
 - Fix error with decimal validation
+
+[1.5.4]
+
+- Fix error when building with a parameter that is a optional pydantic model [Issue #56] @phbernardes

--- a/pydantic_factories/factory.py
+++ b/pydantic_factories/factory.py
@@ -78,6 +78,7 @@ from pydantic import (
     StrictStr,
 )
 from pydantic.color import Color
+from pydantic.fields import SHAPE_MAPPING
 from typing_extensions import get_args
 
 from pydantic_factories.constraints.constrained_collection_handler import (
@@ -494,7 +495,7 @@ class ModelFactory(ABC, Generic[T]):
         Returns False if model_field isn't a Pydantic model OR if all fields of the pydantic model are defined in the kwargs, and True otherwise.
         """
         pydantic_model = model_field.type_
-        if not is_pydantic_model(pydantic_model):
+        if not is_pydantic_model(pydantic_model) or model_field.shape == SHAPE_MAPPING:
             return False
 
         list_of_pydantic_models_kwargs = kwargs[field_name]


### PR DESCRIPTION
This aims to solve issue #61.

Partial attributes factory for Mapping fields will not be supported yet as it requires a more advanced data manipulation.

This means that given the following models:

```python
class NestedSchema(BaseModel):
    v: str
    z: int


class UpperSchema(BaseModel):
    a: int
    b: Mapping[str, str]
    nested: Mapping[str, NestedSchema]


class NestedSchemaFactory(ModelFactory):
    __model__ = NestedSchema


class UpperSchemaFactory(ModelFactory):
    __model__ = UpperSchema
```

The case of the issue will work fine:

```python
def test_factory_not_ok():
    nested = NestedSchema(v="hello", z=0)
    some_dict = {"test": "fine"}
    upper = UpperSchemaFactory.build(b=some_dict, nested={"nested": nested})
```

But no support is given yet for:

```python
def test_factory_not_ok():
    nested = NestedSchema(v="hello", z=0)
    data = {"b": {"test": "fine"}, "nested" {"nested_key": {"v": "hello"}}}
    upper = UpperSchemaFactory.build(** data)
```

A random value for z will not be generated by the factory yet. But this is an edge case that was not handled before 1.5.0 anyway.


